### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.root_account master: https://github.com/debops/ansible-root_account/compare/v0.1.0...master
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 debops.root_account v0.1.0 - 2017-02-21
 ---------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,8 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 debops.root_account v0.1.0 - 2017-02-21

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 debops.root_account v0.1.0 - 2017-02-21

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   author: 'Fabio Bonelli'
   description: 'Manage the root account'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   shell: ssh -Q key 2>/dev/null || echo "ssh-rsa"
   register: root_account__register_key_types
   changed_when: False
-  check_mode: no
+  check_mode: False
 
 - name: Enforce root system group
   group:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   shell: ssh -Q key 2>/dev/null || echo "ssh-rsa"
   register: root_account__register_key_types
   changed_when: False
-  always_run: True
+  check_mode: no
 
 - name: Enforce root system group
   group:


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.